### PR TITLE
Send a metric on catching an exception

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,15 @@ Dogcatcher.configure do |c|
 end
 ```
 
+Metrics will be sent with a default name of `dogcatcher.errors.count`, this can
+be customized by setting the `metric_name` configurable.
+
+```ruby
+Dogcatcher.configure do |c|
+  c.metric_name = 'my_app.errors.count'
+end
+```
+
 The host and port that statsd data is sent to can be configured like so.
 
 ```ruby

--- a/README.md
+++ b/README.md
@@ -56,9 +56,9 @@ end
 
 ## Configuration
 
-By default Dogcatcher will send events to statsd running on the local host. By
-specifying a Datadog API key, Dogcatcher will switch to sending events to the
-Datadog API instead.
+By default Dogcatcher will send metric and event data to statsd running on the
+local host. By specifying a Datadog API key, Dogcatcher will switch to sending
+events to the Datadog API instead.
 
 ```ruby
 Dogcatcher.configure do |c|
@@ -66,8 +66,8 @@ Dogcatcher.configure do |c|
 end
 ```
 
-Since the default approach is to send events to one or the other, options are
-available to explicitly control where the events are sent.
+Since the default approach is to send data to one or the other, options are
+available to explicitly control where the data is sent.
 
 ```ruby
 Dogcatcher.configure do |c|
@@ -76,7 +76,17 @@ Dogcatcher.configure do |c|
 end
 ```
 
-The host and port that statsd events are sent to can be configured like so.
+By default Dogcatcher will send both metrics and events, but these can be
+disabled individually.
+
+```ruby
+Dogcatcher.configure do |c|
+  c.send_metric = false
+  c.send_event = false
+end
+```
+
+The host and port that statsd data is sent to can be configured like so.
 
 ```ruby
 Dogcatcher.configure do |c|
@@ -86,7 +96,7 @@ end
 ```
 
 An optional program name can be specified to help distinguish between multiple
-applications. This will appear in the event title.
+applications. This will appear in the event title and as a tag on the metric.
 
 ```ruby
 Dogcatcher.configure do |c|
@@ -116,7 +126,7 @@ Dogcatcher.configure do |c|
 end
 ```
 
-Custom tags can be sent with exception events by adding them to the config.
+Custom tags can be sent with exception data by adding them to the config.
 
 ```ruby
 Dogcatcher.configure do |c|

--- a/lib/dogcatcher/config.rb
+++ b/lib/dogcatcher/config.rb
@@ -23,6 +23,14 @@ module Dogcatcher
     attr_accessor :use_dogapi
     attr_accessor :use_statsd
 
+    # When true, a metric will be sent via the enabled method.
+    attr_accessor :send_metric
+    # When true, an event will be sent via the enabled method.
+    attr_accessor :send_event
+
+    # Name of the metric that will be sent
+    attr_accessor :metric_name
+
     # When enabled it will add tags for each +gem_name:version+ found in the
     # backtrace.
     #
@@ -37,12 +45,17 @@ module Dogcatcher
     # Custom tags to send with exception events
     attr_accessor :custom_tags
 
+    DEFAULT_METRIC_NAME = 'dogcatcher.errors.count'
+
     def initialize
       @statsd_host = '127.0.0.1'
       @statsd_port = 8125
       @gem_tags = true
       @backtrace_cleaner = ActiveSupport::BacktraceCleaner.new
       @custom_tags = []
+      @send_metric = true
+      @send_event = true
+      @metric_name = DEFAULT_METRIC_NAME
     end
 
     # Adds a backtrace filter. The given line in the backtrace will be replaced

--- a/spec/dogcatcher/notifier_spec.rb
+++ b/spec/dogcatcher/notifier_spec.rb
@@ -3,18 +3,44 @@ require 'spec_helper'
 describe Dogcatcher::Notifier do
   let(:use_dogapi) { nil }
   let(:use_statsd) { nil }
+  let(:send_event) { nil }
+  let(:send_metric) { nil }
   let(:notice) { double('Notice') }
-  let(:config) { double('Config', use_dogapi?: use_dogapi, use_statsd?: use_statsd) }
+  let(:config) { double('Config', use_dogapi?: use_dogapi, use_statsd?: use_statsd, send_event: send_event, send_metric: send_metric) }
 
   subject { described_class.new(config) }
 
   describe '#notify' do
     context 'when use_dogapi is true' do
       let(:use_dogapi) { true }
+      context 'when send_event is true' do
+        let(:send_event) { true }
+        it 'notifies dogapi via event' do
+          expect(subject).to receive(:notify_dogapi_event).with(notice)
+          subject.notify(notice)
+        end
+      end
+      context 'when send_event is false' do
+        let(:send_event) { false }
+        it 'does not notify dogapi via event' do
+          expect(subject).to_not receive(:notify_dogapi_event).with(notice)
+          subject.notify(notice)
+        end
+      end
 
-      it 'notifies dogapi' do
-        expect(subject).to receive(:notify_dogapi).with(notice)
-        subject.notify(notice)
+      context 'when send_metric is true' do
+        let(:send_metric) { true }
+        it 'notifies dogapi via metric' do
+          expect(subject).to receive(:notify_dogapi_metric).with(notice)
+          subject.notify(notice)
+        end
+      end
+      context 'when send_metric is false' do
+        let(:send_metric) { false }
+        it 'does not notify dogapi via metric' do
+          expect(subject).to_not receive(:notify_dogapi_metric).with(notice)
+          subject.notify(notice)
+        end
       end
     end
 
@@ -22,7 +48,8 @@ describe Dogcatcher::Notifier do
       let(:use_dogapi) { false }
 
       it 'does not notify dogapi' do
-        expect(subject).to_not receive(:notify_dogapi).with(notice)
+        expect(subject).to_not receive(:notify_dogapi_event).with(notice)
+        expect(subject).to_not receive(:notify_dogapi_metric).with(notice)
         subject.notify(notice)
       end
     end
@@ -30,9 +57,34 @@ describe Dogcatcher::Notifier do
     context 'when use_statsd is true' do
       let(:use_statsd) { true }
 
-      it 'notifies statsd' do
-        expect(subject).to receive(:notify_statsd).with(notice)
-        subject.notify(notice)
+      context 'when send_event is true' do
+        let(:send_event) { true }
+        it 'notifies statsd via event' do
+          expect(subject).to receive(:notify_statsd_event).with(notice)
+          subject.notify(notice)
+        end
+      end
+      context 'when send_event is false' do
+        let(:send_event) { false }
+        it 'does not notify statsd via event' do
+          expect(subject).to_not receive(:notify_statsd_event).with(notice)
+          subject.notify(notice)
+        end
+      end
+
+      context 'when send_metric is true' do
+        let(:send_metric) { true }
+        it 'notifies statsd via metric' do
+          expect(subject).to receive(:notify_statsd_metric).with(notice)
+          subject.notify(notice)
+        end
+      end
+      context 'when send_metric is false' do
+        let(:send_metric) { false }
+        it 'does not notify statsd via metric' do
+          expect(subject).to_not receive(:notify_statsd_metric).with(notice)
+          subject.notify(notice)
+        end
       end
     end
 


### PR DESCRIPTION
These changes cause dogcatcher to send a `dogcatcher.errors.count` metric (customizable by the `metric_name` config option), that can be used to graph the failures.

Both sending events and metrics can be toggled by setting the `send_metric` or `send_event` config options to `false`, the default is to send both.
